### PR TITLE
04: Sulu-Admin form

### DIFF
--- a/Resources/public/js/components/news/form/form.html
+++ b/Resources/public/js/components/news/form/form.html
@@ -1,0 +1,10 @@
+<form id="news-form" class="grid">
+    <div class="form-group grid-row">
+        <label for="news-title"><%= translations.title %></label>
+        <input type="text" id="news-title" name="title" class="form-element input-bold required" data-mapper-property="title" data-validation-required="true"/>
+    </div>
+    <div class="form-group">
+        <label for="news-content"><%= translations.content %></label>
+        <textarea id="news-content" name="content" class="form-element" data-mapper-property="content"></textarea>
+    </div>
+</form>

--- a/Resources/public/js/components/news/form/main.js
+++ b/Resources/public/js/components/news/form/main.js
@@ -4,7 +4,8 @@ define(['text!./form.html'], function(form) {
 
         defaults: {
             templates: {
-                form: form
+                form: form,
+                url: '/admin/api/news<% if (!!id) { %>/<%= id %><% } %>'
             },
             translations: {
                 title: 'public.title',
@@ -35,6 +36,7 @@ define(['text!./form.html'], function(form) {
             this.render();
 
             this.bindDomEvents();
+            this.bindCustomEvents();
         },
 
         render: function() {
@@ -47,6 +49,34 @@ define(['text!./form.html'], function(form) {
             this.$el.find('input, textarea').on('keypress', function() {
                 this.sandbox.emit('sulu.header.toolbar.item.enable', 'save');
             }.bind(this));
+        },
+
+        bindCustomEvents: function() {
+            this.sandbox.on('sulu.toolbar.save', this.save.bind(this));
+        },
+
+        save: function(action) {
+            if (!this.sandbox.form.validate('#news-form')) {
+                return;
+            }
+
+            var data = this.sandbox.form.getData('#news-form');
+
+            this.sandbox.util.save(this.templates.url({id:null}), 'POST', data).then(function(response) {
+                this.afterSave(response, action);
+            }.bind(this));
+        },
+
+        afterSave: function(response, action) {
+            this.sandbox.emit('sulu.header.toolbar.item.disable', 'save');
+
+            if (action === 'back') {
+                this.sandbox.emit('sulu.router.navigate', 'example/news');
+            } else if (action === 'new') {
+                this.sandbox.emit('sulu.router.navigate', 'example/news/add');
+            } else if (!this.options.id) {
+                this.sandbox.emit('sulu.router.navigate', 'example/news/edit:' + response.id);
+            }
         }
     };
 });

--- a/Resources/public/js/components/news/form/main.js
+++ b/Resources/public/js/components/news/form/main.js
@@ -1,0 +1,27 @@
+define(function() {
+    return {
+
+        header: {
+            title: 'news.headline',
+            toolbar: {
+                buttons: {
+                    save: {
+                        parent: 'saveWithOptions'
+                    }
+                }
+            }
+        },
+
+        layout: {
+            content: {
+                width: 'fixed',
+                leftSpace: true,
+                rightSpace: true
+            }
+        },
+
+        initialize: function() {
+            this.$el.html('<h1>Hello awesome sulu world</h1>');
+        }
+    };
+});

--- a/Resources/public/js/components/news/form/main.js
+++ b/Resources/public/js/components/news/form/main.js
@@ -1,5 +1,16 @@
-define(function() {
+define(['text!./form.html'], function(form) {
+
     return {
+
+        defaults: {
+            templates: {
+                form: form
+            },
+            translations: {
+                title: 'public.title',
+                content: 'news.content'
+            }
+        },
 
         header: {
             title: 'news.headline',
@@ -21,7 +32,21 @@ define(function() {
         },
 
         initialize: function() {
-            this.$el.html('<h1>Hello awesome sulu world</h1>');
+            this.render();
+
+            this.bindDomEvents();
+        },
+
+        render: function() {
+            this.$el.html(this.templates.form({translations: this.translations}));
+
+            this.sandbox.form.create('#news-form');
+        },
+
+        bindDomEvents: function() {
+            this.$el.find('input, textarea').on('keypress', function() {
+                this.sandbox.emit('sulu.header.toolbar.item.enable', 'save');
+            }.bind(this));
         }
     };
 });

--- a/Resources/public/js/main.js
+++ b/Resources/public/js/main.js
@@ -23,6 +23,13 @@ define(function() {
                     return '<div data-aura-component="news/list@examplenews" data-aura-name="sulu" />';
                 }
             });
+
+            app.sandbox.mvc.routes.push({
+                route: 'example/news/add',
+                callback: function() {
+                    return '<div data-aura-component="news/form@examplenews"/>';
+                }
+            });
         }
     };
 });

--- a/Resources/public/js/main.js
+++ b/Resources/public/js/main.js
@@ -30,6 +30,13 @@ define(function() {
                     return '<div data-aura-component="news/form@examplenews"/>';
                 }
             });
+
+            app.sandbox.mvc.routes.push({
+                route: 'example/news/edit::id',
+                callback: function(id) {
+                    return '<div data-aura-component="news/form@examplenews" data-aura-id="' + id + '"/>';
+                }
+            });
         }
     };
 });


### PR DESCRIPTION
This part of the tutorial bootstraps the add and edit form for news-items in the Sulu-Admin

Link to the Blog-Post: http://blog.sulu.io/how-to-develop-a-bundle-in-the-sulu-admin-4
